### PR TITLE
Binary ops

### DIFF
--- a/docs/src/api/binary_ops.rst
+++ b/docs/src/api/binary_ops.rst
@@ -1,0 +1,4 @@
+binary_ops.h
+============
+
+.. doxygenfile:: binary_ops.h

--- a/docs/src/api/function_mapping.rst
+++ b/docs/src/api/function_mapping.rst
@@ -1,4 +1,4 @@
 function_mapping.h
 ==================
 
-.. doxygenfunction:: slap_Map
+.. doxygenfile:: function_mapping.h

--- a/docs/src/basic_ops.rst
+++ b/docs/src/basic_ops.rst
@@ -15,13 +15,25 @@ These operations all operate on the data in the array.
 ============================== ====================================
 Function                       Header
 ============================== ====================================
-:cpp:func:`slap_SetConst`      ``src/unary_opts.h``
+:cpp:func:`slap_SetConst`      ``src/unary_ops.h``
 :cpp:func:`slap_ScaleByConst`  ``src/unary_ops.h``
 :cpp:func:`slap_SetIdentity`   ``src/unary_ops.h``
 :cpp:func:`slap_SetDiagonal`   ``src/unary_ops.h``
 :cpp:func:`slap_AddIdentity`   ``src/unary_ops.h``
 :cpp:func:`slap_SetRange`      ``src/unary_ops.h``
 ============================== ====================================
+
+Binary Operations
+-----------------
+These calculations take in two matrices. The input matrices can usually
+be aliased, but check verify in the documentation for each function.
+
+======================================= ====================================
+Function                                Header
+======================================= ====================================
+:cpp:func:`slap_MatrixAddition`         ``src/binary_opts.h``
+:cpp:func:`slap_MatrixNormedDifference` ``src/binary_ops.h``
+======================================= ====================================
 
 
 Transformations

--- a/docs/src/basic_ops.rst
+++ b/docs/src/basic_ops.rst
@@ -21,6 +21,7 @@ Function                       Header
 :cpp:func:`slap_SetDiagonal`   ``src/unary_ops.h``
 :cpp:func:`slap_AddIdentity`   ``src/unary_ops.h``
 :cpp:func:`slap_SetRange`      ``src/unary_ops.h``
+:cpp:func:`slap_Map`           ``src/unary_ops.h``
 ============================== ====================================
 
 Binary Operations
@@ -33,6 +34,7 @@ Function                                Header
 ======================================= ====================================
 :cpp:func:`slap_MatrixAddition`         ``src/binary_opts.h``
 :cpp:func:`slap_MatrixNormedDifference` ``src/binary_ops.h``
+:cpp:func:`slap_BinaryMap`              ``src/binary_ops.h``
 ======================================= ====================================
 
 

--- a/src/slap/binary_ops.c
+++ b/src/slap/binary_ops.c
@@ -18,7 +18,7 @@ double slap_MatrixNormedDifference(const Matrix A, const Matrix B) {
   }
   return sqrt(diff);
 }
-enum slap_ErrorCode slap_MatAdd(Matrix C, const Matrix A, const Matrix B, double alpha) {
+enum slap_ErrorCode slap_MatrixAddition(Matrix C, Matrix A, Matrix B, double alpha) {
   SLAP_ASSERT_VALID(C, SLAP_INVALID_MATRIX, "MatAdd: C matrix invalid");
   SLAP_ASSERT_VALID(A, SLAP_INVALID_MATRIX, "MatAdd: A matrix invalid");
   SLAP_ASSERT_VALID(B, SLAP_INVALID_MATRIX, "MatAdd: B matrix invalid");

--- a/src/slap/binary_ops.h
+++ b/src/slap/binary_ops.h
@@ -1,3 +1,11 @@
+/**
+ * @file binary_ops.h
+ * @author Brian Jackson (bjack205@gmail.com)
+ * @copyright Copyright (c) 2022
+ * @date 2023-01-30
+ *
+ * @brief Operations between two matrices
+ */
 #pragma once
 
 #include "matrix.h"
@@ -13,4 +21,29 @@
  */
 double slap_MatrixNormedDifference(Matrix A, Matrix B);
 
-enum slap_ErrorCode slap_MatAdd(Matrix C, Matrix A, Matrix B, double alpha);
+/**
+ * @brief Add two matrices, with scaling
+ *
+ * Calculates \f$C = A + \alpha B\f$
+ *
+ * Matrices must all be the same size.
+ *
+ * Any of the matrices can be aliased.
+ *
+ * # Examples
+ * Normal matrix addition
+ * ```c
+ * slap_MatrixAddition(C, A, B, 1.0);
+ * ```
+ *
+ * Subtract a matrix from another, in-place
+ * ```c
+ * slap_MatrixAddition(A, A, B, -1);
+ * ```
+ *
+ * @param[out] C Destination matrix
+ * @param[in] A Input matrix
+ * @param[in] B Input matrix
+ * @param alpha Scaling on B
+ */
+enum slap_ErrorCode slap_MatrixAddition(Matrix C, Matrix A, Matrix B, double alpha);

--- a/src/slap/function_mapping.c
+++ b/src/slap/function_mapping.c
@@ -15,3 +15,23 @@ enum slap_ErrorCode slap_Map(Matrix mat, double (*function)(double)) {
   }
   return SLAP_NO_ERROR;
 }
+enum slap_ErrorCode slap_BinaryMap(Matrix C, Matrix A, Matrix B,
+                                   double (*function)(double, double)) {
+  // Check for valid matrices
+  SLAP_ASSERT_VALID(C, SLAP_INVALID_MATRIX, "BinaryMap: invalid output C matrix");
+  SLAP_ASSERT_VALID(A, SLAP_INVALID_MATRIX, "BinaryMap: invalid input A matrix");
+  SLAP_ASSERT_VALID(B, SLAP_INVALID_MATRIX, "BinaryMap: invalid input B matrix");
+
+  // Check that matrices have the same size
+  SLAP_ASSERT_SAME_SIZE(C,A, SLAP_INCOMPATIBLE_MATRIX_DIMENSIONS, "slap_BinaryMap");
+  SLAP_ASSERT_SAME_SIZE(A,B, SLAP_INCOMPATIBLE_MATRIX_DIMENSIONS, "slap_BinaryMap");
+
+  for (MatrixIterator it = slap_Iterator(C); !slap_IsFinished(&it); slap_Step(&it)) {
+    // NOTE: use Cartesian indexing on A,B because they might have different strides
+    double *Ck = C.data + it.index;
+    double Ak = *slap_GetElement(A, it.i, it.j);
+    double Bk = *slap_GetElement(B, it.i, it.j);
+    *Ck = function(Ak, Bk);
+  }
+  return SLAP_NO_ERROR;
+}

--- a/src/slap/function_mapping.h
+++ b/src/slap/function_mapping.h
@@ -24,3 +24,35 @@
  * @return
  */
 enum slap_ErrorCode slap_Map(Matrix mat, double (*function)(double));
+
+/**
+ * @brief Applies a function element-wise to a pair of matrices
+ *
+ * Given a function pointer \f$c = f(x,y)\f$, this function applies
+ * this operation element-wise, storing the output in C.
+ *
+ * The matrices must all be the same size (but can have different strides).
+ *
+ * The matrices can be aliased.
+ *
+ * # Example
+ * ```double c
+ * double binary_op(double x, double y) {
+ *   return 2 * x - y * x;
+ * }
+ *
+ * int main() {
+ * // Initialize matrices ...
+ * slap_BinaryMap(C, A, B, binary_op);
+ * // Clean-up operations ...
+ * }
+ * ```
+ * For more details, see the `BinaryMap` test in `test/matrix_test.cpp`.
+ *
+ * @param[out] C Destination matrix
+ * @param[in] A Input matrix, provides first arguments to function
+ * @param[in] B Input matrix, provides second arguments to function
+ * @param function A function that takes two doubles and returns a double
+ */
+enum slap_ErrorCode slap_BinaryMap(Matrix C, Matrix A, Matrix B,
+                                   double (*function)(double, double));

--- a/src/slap/matrix.h
+++ b/src/slap/matrix.h
@@ -400,17 +400,6 @@ static inline void slap_SetElement(Matrix mat, int row, int col, double val) {
   mat.data[slap_Cart2Index(mat, row, col)] = val;
 }
 
-/**
- * @brief Return the normed difference between 2 matrices of the same size
- *
- * Returns \f$ \sqrt{\sum_{i=0}^{m-1} \sum_{j=0}^{n-1} (A_{ij} - B_{ij})^2 } \f$
- *
- * @param A A matrix of dimension (m,n)
- * @param B A matrix of dimension (m,n)
- * @return
- */
-double slap_MatrixNormedDifference(Matrix A, Matrix B);
-
 //*********************************************//
 // Transformations
 //*********************************************//

--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -323,7 +323,7 @@ TEST(MatrixUnaryOps, MatrixScale) {
   }
 }
 
-TEST(MatrixUnaryOpts, SetDiagonal) {
+TEST(MatrixUnaryOps, SetDiagonal) {
   enum slap_ErrorCode err;
   double dataA[6] = {1, 2, 3, 4, 5, 6};
   double data_diag[2] = {10,11};
@@ -417,6 +417,58 @@ TEST(MatrixBinaryOps, NormedDiff) {
   EXPECT_DOUBLE_EQ(err, 0);
   err = slap_MatrixNormedDifference(A, B);
   EXPECT_DOUBLE_EQ(err, 2);
+}
+
+TEST(MatrixBinaryOps, Addition) {
+  double dataA[6] = {1, 2, 3, 4, 5, 6};
+  double dataB[6] = {3, 2, -1, -4, 10, 0};
+  double dataC[6];
+  double dataD[6] = {4, 4, 2, 0, 15, 6};
+  Matrix A = slap_MatrixFromArray(2, 3, dataA);
+  Matrix B = slap_MatrixFromArray(2, 3, dataB);
+  Matrix C = slap_MatrixFromArray(2, 3, dataC);
+  Matrix D = slap_MatrixFromArray(2, 3, dataD);
+  slap_MatrixAddition(C, A, B, 1.0);
+  double err = slap_MatrixNormedDifference(C, D);
+  EXPECT_LT(err, 1e-6);
+
+  // Aliased addition
+  slap_MatrixAddition(A, B, A, 1.0);
+  err = slap_MatrixNormedDifference(A, D);
+  EXPECT_LT(err, 1e-6);
+}
+
+TEST(MatrixBinaryOps, Subtraction) {
+  double dataA[6] = {1, 2, 3, 4, 5, 6};
+  double dataB[6] = {3, 2, -1, -4, 10, 0};
+  double dataC[6];
+  double dataD[6] = {-2, 0, 4, 8, -5, 6};
+  Matrix A = slap_MatrixFromArray(2, 3, dataA);
+  Matrix B = slap_MatrixFromArray(2, 3, dataB);
+  Matrix C = slap_MatrixFromArray(2, 3, dataC);
+  Matrix D = slap_MatrixFromArray(2, 3, dataD);
+  slap_MatrixAddition(C, A, B, -1.0);
+  double err = slap_MatrixNormedDifference(C, D);
+  EXPECT_LT(err, 1e-6);
+
+  // Aliased subtraction
+  slap_MatrixAddition(A, A, B, -1.0);
+  err = slap_MatrixNormedDifference(A, D);
+  EXPECT_LT(err, 1e-6);
+}
+
+TEST(MatrixBinaryOps, AdditionWithScaling) {
+  double dataA[6] = {1, 2, 3, 4, 5, 6};
+  double dataB[6] = {3, 2, -1, -4, 10, 0};
+  double dataC[6];
+  double dataD[6] = {4.5, 5, 3.5, 2, 17.5, 9};
+  Matrix A = slap_MatrixFromArray(2, 3, dataA);
+  Matrix B = slap_MatrixFromArray(2, 3, dataB);
+  Matrix C = slap_MatrixFromArray(2, 3, dataC);
+  Matrix D = slap_MatrixFromArray(2, 3, dataD);
+  slap_MatrixAddition(C, B, A, 1.5);
+  double err = slap_MatrixNormedDifference(C, D);
+  EXPECT_LT(err, 1e-6);
 }
 
 TEST(MatrixTransformations, Flatten) {

--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -471,6 +471,30 @@ TEST(MatrixBinaryOps, AdditionWithScaling) {
   EXPECT_LT(err, 1e-6);
 }
 
+double binary_op(double x, double y) {
+   return 2 * x - y * x;
+}
+
+TEST(MatrixBinaryOps, BinaryMap) {
+  double dataA[6] = {1, 2, 3, 4, 5, 6};
+  double dataB[6] = {3, 2, -1, -4, 10, 0};
+  double dataC[6];
+  double dataD[6] = {-1, 0, 9, 24, -40, 12};
+  Matrix A = slap_MatrixFromArray(2, 3, dataA);
+  Matrix B = slap_MatrixFromArray(2, 3, dataB);
+  Matrix C = slap_MatrixFromArray(2, 3, dataC);
+  Matrix D = slap_MatrixFromArray(2, 3, dataD);
+  slap_BinaryMap(C, A, B, binary_op);
+  double err = slap_MatrixNormedDifference(C, D);
+  EXPECT_LT(err, 1e-6);
+
+  // Aliased
+  slap_BinaryMap(A, A, B, binary_op);
+  err = slap_MatrixNormedDifference(A, D);
+  EXPECT_LT(err, 1e-6);
+}
+
+
 TEST(MatrixTransformations, Flatten) {
   double dataA[6] = {1, 2, 3, 4, 5, 6};
   Matrix A = slap_MatrixFromArray(2, 3, dataA);


### PR DESCRIPTION
Adds documentation for addition operation, which was renamed to `slap_MatrixAddition`. Closes #14 

Adds a method for applying an arbitrary function between two matrices, element-wise, `slap_BinaryMap`. Closes #15.