### PR TITLE
Change FreeMatrix to use pointer. Add some tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,6 +69,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
+       token: ${{ secrets.CODECOV_TOKEN }}
        gcov: true
        fail_ci_if_error: true
 #    - name: Process code coverage results

--- a/examples/getting_started.c
+++ b/examples/getting_started.c
@@ -306,10 +306,10 @@ int main(void) {
   /////////////////////////////////////////////
 
   free(data_B);
-  slap_FreeMatrix(x);
-  slap_FreeMatrix(y);
-  slap_FreeMatrix(z);
-  slap_FreeMatrix(Z);
-  slap_FreeMatrix(C);
+  slap_FreeMatrix(&x);
+  slap_FreeMatrix(&y);
+  slap_FreeMatrix(&z);
+  slap_FreeMatrix(&Z);
+  slap_FreeMatrix(&C);
   return EXIT_SUCCESS;
 }

--- a/src/slap/new_matrix.c
+++ b/src/slap/new_matrix.c
@@ -29,10 +29,10 @@ Matrix slap_NewMatrixZeros(int rows, int cols) {
   return mat;
 }
 
-enum slap_ErrorCode slap_FreeMatrix(Matrix mat) {
-  if (mat.data) {
-    free(mat.data);
-    mat.data = NULL;
+enum slap_ErrorCode slap_FreeMatrix(Matrix* mat) {
+  if (mat->data) {
+    free(mat->data);
+    mat->data = NULL;
     return SLAP_NO_ERROR;
   }
   return SLAP_BAD_MATRIX_DATA_POINTER;

--- a/src/slap/new_matrix.h
+++ b/src/slap/new_matrix.h
@@ -54,6 +54,9 @@ Matrix slap_NewMatrixZeros(int rows, int cols);
 /**
  * @brief Free the data for a matrix
  *
+ * Note that this methods takes the pointer to the matrix as a argument, so that it can
+ * set the internal data pointer to NULL after the free.
+ *
  * Note this does NOT attempt to free the matrix object itself, only the data
  * it wraps.
  *
@@ -61,4 +64,4 @@ Matrix slap_NewMatrixZeros(int rows, int cols);
  *
  * **Header File:** `"slap/new_matrix.h"`
  */
-enum slap_ErrorCode slap_FreeMatrix(Matrix mat);
+enum slap_ErrorCode slap_FreeMatrix(Matrix* mat);

--- a/test/linear_algebra_test.cpp
+++ b/test/linear_algebra_test.cpp
@@ -112,7 +112,7 @@ TEST_F(LinearAlgebraTest, CholeskyFactorization) {
   err = slap_Cholesky(Achol);
   EXPECT_EQ(err, SLAP_CHOLESKY_FAIL);
 
-  slap_FreeMatrix(A);
+  slap_FreeMatrix(&A);
 }
 
 TEST_F(LinearAlgebraTest, TriBackSub) {
@@ -162,9 +162,9 @@ TEST_F(LinearAlgebraTest, CholeskySolve) {
   slap_MatMulAB(b2, A, x);
   EXPECT_LT(slap_MatrixNormedDifference(b2, b), 1e-10);
 
-  slap_FreeMatrix(A);
-  slap_FreeMatrix(x);
-  slap_FreeMatrix(b2);
+  slap_FreeMatrix(&A);
+  slap_FreeMatrix(&x);
+  slap_FreeMatrix(&b2);
 }
 
 class QRDecompTest : public ::testing::Test {
@@ -264,10 +264,10 @@ TEST_F(QRDecompTest, QRDecomp_Square) {
   EXPECT_LT(diff, 1e-10);
 
   // Clean up temporaries
-  slap_FreeMatrix(Q);
-  slap_FreeMatrix(Q_work);
-  slap_FreeMatrix(I_m);
-  slap_FreeMatrix(QR);
+  slap_FreeMatrix(&Q);
+  slap_FreeMatrix(&Q_work);
+  slap_FreeMatrix(&I_m);
+  slap_FreeMatrix(&QR);
 }
 
 TEST_F(QRDecompTest, QRDecomp_Skinny) {
@@ -297,10 +297,10 @@ TEST_F(QRDecompTest, QRDecomp_Skinny) {
   EXPECT_LT(diff, 1e-10);
 
   // Clean up temporaries
-  slap_FreeMatrix(Q);
-  slap_FreeMatrix(Q_work);
-  slap_FreeMatrix(I_m);
-  slap_FreeMatrix(QR);
+  slap_FreeMatrix(&Q);
+  slap_FreeMatrix(&Q_work);
+  slap_FreeMatrix(&I_m);
+  slap_FreeMatrix(&QR);
 }
 
 TEST_F(QRDecompTest, QRDecomp_LeastSquares) {

--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -19,7 +19,27 @@ TEST(MatrixBasics, NewMatrix) {
   EXPECT_EQ(mat.rows, 5);
   EXPECT_EQ(mat.cols, 4);
   EXPECT_EQ(slap_NumElements(mat), 20);
-  slap_FreeMatrix(mat);
+  slap_FreeMatrix(&mat);
+}
+
+TEST(MatrixBasics, NewMatrix_Zeros) {
+  Matrix mat = slap_NewMatrixZeros(5, 4);
+  EXPECT_EQ(mat.rows, 5);
+  EXPECT_EQ(mat.cols, 4);
+  EXPECT_EQ(slap_NumElements(mat), 20);
+  for (int i = 0; i < 20; ++i) {
+    EXPECT_DOUBLE_EQ(mat.data[i], 0);
+  }
+  slap_FreeMatrix(&mat);
+}
+
+TEST(MatrixBasics, NewMatrix_DoubleFree) {
+  Matrix mat = slap_NewMatrixZeros(5, 4);
+  enum slap_ErrorCode code = slap_FreeMatrix(&mat);
+  EXPECT_EQ(code, SLAP_NO_ERROR);
+  code = slap_FreeMatrix(&mat);
+  EXPECT_EQ(code, SLAP_BAD_MATRIX_DATA_POINTER);
+
 }
 
 TEST(MatrixBasics, GetLinearIndex_2x3) {
@@ -532,3 +552,12 @@ TEST(MatrixTransformations, Reshape) {
   EXPECT_EQ(slap_Cart2Index(B, 0, 1), 2);
   EXPECT_EQ(*slap_GetElement(B, 0, 1), 3);
 }
+
+TEST(MatrixPrinting, PrintRow) {
+  double data_x[4] = {1,2,3,4};
+  Matrix x = slap_MatrixFromArray(4, 1, data_x);
+  slap_PrintRowVector(x);
+  slap_PrintRowVector(slap_Transpose(x));
+}
+
+

--- a/test/vector_test.cpp
+++ b/test/vector_test.cpp
@@ -91,13 +91,28 @@ TEST_F(VectorTests, QuadraticForm) {
   EXPECT_DOUBLE_EQ(dot, 1522.5);
 }
 
+TEST_F(VectorTests, QuadraticForm_BadPointers) {
+  double data_A[DATA_LEN * (DATA_LEN + 3)] = {1.0, -4.0, 1.0, -5.0, -9.0, 10.0, 5.0, 3.0, 8.0, 0.0, -6.0, 8.0, 1.0, 3.0, -7.0, -9.0, -2.0, -10.0, -3.0, -3.0, 9.0, 2.0, -8.0, 1.0, 0.0, 1.0, 1.0, -4.0, 0.0, 0.0, -8.0, -6.0, -8.0, 7.0, 7.0, -8.0, -2.0, -4.0, 0.0, -9.0, 9.0, -7.0, 0.0, -6.0, -8.0, 6.0, 10.0, -6.0, 8.0, 6.0, -6.0, 2.0, 9.0, 2.0};
+  Matrix A = slap_MatrixFromArray(DATA_LEN + 3, DATA_LEN, NULL);
+  double dot = slap_QuadraticForm(y, A, x);
+  EXPECT_TRUE(isnan(dot));
+
+  A.data = data_A;
+  y.data = NULL;
+  dot = slap_QuadraticForm(y, A, x);
+
+  y.data = data_y;
+  x.data = NULL;
+  dot = slap_QuadraticForm(y, A, x);
+}
+
 TEST_F(VectorTests, OuterProduct) {
   double data_C[DATA_LEN * (DATA_LEN + 3)] = {5.0, 5.0, 4.0, 3.0, -2.0, 8.0, 8.0, -8.0, 9.0, 0.0, 0.0, 0.0, 0.0, -0.0, 0.0, 0.0, -0.0, 0.0, -30.0, -30.0, -24.0, -18.0, 12.0, -48.0, -48.0, 48.0, -54.0, -50.0, -50.0, -40.0, -30.0, 20.0, -80.0, -80.0, 80.0, -90.0, 2.5, 2.5, 2.0, 1.5, -1.0, 4.0, 4.0, -4.0, 4.5, 5.0, 5.0, 4.0, 3.0, -2.0, 8.0, 8.0, -8.0, 9.0};
   Matrix C = slap_MatrixFromArray(DATA_LEN + 3, DATA_LEN, data_C);
   Matrix A = slap_NewMatrix(DATA_LEN + 3, DATA_LEN);
   slap_OuterProduct(A, y, x);
   EXPECT_LT(slap_MatrixNormedDifference(A, C), 1e-10);
-  slap_FreeMatrix(A);
+  slap_FreeMatrix(&A);
 }
 
 TEST_F(VectorTests, CrossProduct_OutputTooShort) {
@@ -105,7 +120,7 @@ TEST_F(VectorTests, CrossProduct_OutputTooShort) {
   Matrix z = slap_NewMatrix(2, 1);
   err = slap_CrossProduct(z, x, y);
   EXPECT_EQ(err, SLAP_INCOMPATIBLE_MATRIX_DIMENSIONS);
-  slap_FreeMatrix(z);
+  slap_FreeMatrix(&z);
 }
 
 TEST_F(VectorTests, CrossProduct) {
@@ -122,5 +137,5 @@ TEST_F(VectorTests, CrossProduct) {
   EXPECT_DOUBLE_EQ(z.data[0], -30);
   EXPECT_DOUBLE_EQ(z.data[1], +34);
   EXPECT_DOUBLE_EQ(z.data[2], -5);
-  slap_FreeMatrix(z);
+  slap_FreeMatrix(&z);
 }


### PR DESCRIPTION
Boosts the code coverage by adding a few tests.

Also changes the `slap_FreeMatrix` method to use a pointer instead of a copy.